### PR TITLE
Add suggested env variable for local Wordpress

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -3,3 +3,6 @@ NEXT_PUBLIC_WORDPRESS_URL=https://headlessfw.wpengine.com
 
 # Plugin secret found in WordPress Settings->Headless
 FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET
+
+# Uncomment if using a local Wordpress instance to avoid 'self signed certificate' errors
+# NODE_TLS_REJECT_UNAUTHORIZED=0


### PR DESCRIPTION
I got the following errors after setting up Wordpress with Local. 

[GQtyError: request to https://atlasblueprintbasic.local/graphql failed, reason: self signed certificate]

error - FetchError: request to https://atlasblueprintbasic.local/wp-content/uploads/2022/10/acm-blueprint//media/305/bd703d50-bb83-3d6e-91ec-cb40313ed16f.jpg failed, reason: self signed certificate

It took a while to figure out a solution, and I thought this might help.